### PR TITLE
Add {{filename}} variable in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Inside files you can use the handlebar syntax ```{{variable}}```.
 * ```name_pc```: Name converted to PascalCase
 * ```name_sc```: Name converted to slug-case
 * ```name_cc```: Name converted to CamelCase
+* ```filename```: Filename - different from `name` as it takes into account any '/' included in the arguments.
 
 See default templates for examples.
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -32,7 +32,7 @@ module.exports = function generate(type, options, settings) {
   console.log(chalk.green(chalk.bold(`Generating files from '${type}' template with name: ${options.name}`)));
 
   metalsmith(fullTemplatePath)
-    .metadata(Object.assign({}, getNames(options.name)))
+    .metadata(Object.assign({}, getNames(options.name), { filename: getFilename(options.name) }))
     .source('.')
     .destination(path.resolve(options.destination))
     .clean(false)
@@ -48,6 +48,12 @@ module.exports = function generate(type, options, settings) {
       }
     });
 };
+
+function getFilename(name) {
+  const fileNameSplit = name.split('/');
+  if (fileNameSplit.length === 0) return;
+  return fileNameSplit[fileNameSplit.length - 1];
+}
 
 function getNames(name) {
   return {

--- a/src/generate.js
+++ b/src/generate.js
@@ -51,7 +51,9 @@ module.exports = function generate(type, options, settings) {
 
 function getFilename(name) {
   const fileNameSplit = name.split('/');
-  if (fileNameSplit.length === 0) return;
+  if (fileNameSplit.length === 0) {
+    return name;
+  }
   return fileNameSplit[fileNameSplit.length - 1];
 }
 


### PR DESCRIPTION
I use this library a lot, but have had issues with it including the directory structure into the class name. For example, if I want to make a component in a specific directory like this: 

`vg component Common/Typography/BigText`

with this template:

```
<script lang="ts">
import Vue from 'vue';
import { Component } from 'vue-property-decorator';

@Component
export default class {{name_pc}} extends Vue {

}

Vue.component('{{name_pc}}', {{name_pc}});
</script>

<style module>

</style>

<template>

</template>
```

It will set the Vue component's name to `CommonTypographyBigText`, when I really just want `BigText`. 

This PR exposes a `{{filename}}` variable in templates for use with Vue classes + Vue.component() function calls.