### PR TITLE
upgrade open dependency

### DIFF
--- a/bin/vue-generator-copy-templates
+++ b/bin/vue-generator-copy-templates
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const open = require('open');
 const path = require('path');
 const chalk = require('chalk');
 const program = require('commander');

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "inquirer": "^3.0.5",
     "istextorbinary": "^2.1.0",
     "metalsmith": "^2.3.0",
-    "open": "0.0.5",
+    "open": "^6.1.0",
     "to-camel-case": "^1.0.0",
     "to-pascal-case": "^1.0.0",
     "to-slug-case": "^1.0.0",


### PR DESCRIPTION
- 'open' dependency has had a critical vulnerability
- open has a breaking change after 0.0.5 but for the extremely simple task that it does in the project that shouldn't be an issue.
- also removed a non-necessary import